### PR TITLE
feat: Added v0.3.3 backend for zkvm

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -7,8 +7,14 @@
 //! The function MUST NOT ever write uninitialized bytes into `dest`,
 //! regardless of what value it returns.
 
+mod zkvm;
+
 cfg_if! {
-    if #[cfg(getrandom_backend = "custom")] {
+    if #[cfg(target_arch = "riscv32")] {
+        // Auto-detect SP1 zkVM target
+        pub use zkvm::*;
+    }
+    else if #[cfg(getrandom_backend = "custom")] {
         mod custom;
         pub use custom::*;
     } else if #[cfg(getrandom_backend = "linux_getrandom")] {

--- a/src/backends/zkvm.rs
+++ b/src/backends/zkvm.rs
@@ -1,0 +1,49 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! zkVM implementation using custom backend
+use crate::Error;
+use core::mem::MaybeUninit;
+
+// Main function for getrandom 0.3.3 API - note the MaybeUninit
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe {
+        __getrandom_v03_custom(dest.as_mut_ptr() as *mut u8, dest.len())
+    }
+}
+
+pub fn inner_u32() -> Result<u32, Error> {
+    let mut buf = [MaybeUninit::<u8>::uninit(); 4];
+    fill_inner(&mut buf)?;
+    // Safe because fill_inner initialized the bytes
+    let buf: [u8; 4] = unsafe { core::mem::transmute(buf) };
+    Ok(u32::from_ne_bytes(buf))
+}
+
+pub fn inner_u64() -> Result<u64, Error> {
+    let mut buf = [MaybeUninit::<u8>::uninit(); 8];
+    fill_inner(&mut buf)?;
+    // Safe because fill_inner initialized the bytes
+    let buf: [u8; 8] = unsafe { core::mem::transmute(buf) };
+    Ok(u64::from_ne_bytes(buf))
+}
+
+// Custom backend function - to be overridden by user implementations
+#[no_mangle]
+pub unsafe extern "Rust" fn __getrandom_v03_custom(
+    dest: *mut u8,
+    len: usize,
+) -> Result<(), Error> {
+    // Should be overridden by the correct sp1 implementation. Previous version was:
+    // unsafe { sp1_zkvm::syscalls::sys_rand(s.as_mut_ptr(), s.len()) };
+
+    for i in 0..len {
+        *dest.add(i) = (i as u8).wrapping_mul(17).wrapping_add(42);
+    }
+    Ok(())
+}

--- a/src/backends/zkvm.rs
+++ b/src/backends/zkvm.rs
@@ -11,12 +11,18 @@ use crate::Error;
 use core::mem::MaybeUninit;
 
 // Main function for getrandom 0.3.3 API - note the MaybeUninit
+#[allow(dead_code)]
 pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    extern "Rust" { // Call SP1's version
+        fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
+    }
+
     unsafe {
         __getrandom_v03_custom(dest.as_mut_ptr() as *mut u8, dest.len())
     }
 }
 
+#[allow(dead_code)]
 pub fn inner_u32() -> Result<u32, Error> {
     let mut buf = [MaybeUninit::<u8>::uninit(); 4];
     fill_inner(&mut buf)?;
@@ -25,25 +31,11 @@ pub fn inner_u32() -> Result<u32, Error> {
     Ok(u32::from_ne_bytes(buf))
 }
 
+#[allow(dead_code)]
 pub fn inner_u64() -> Result<u64, Error> {
     let mut buf = [MaybeUninit::<u8>::uninit(); 8];
     fill_inner(&mut buf)?;
     // Safe because fill_inner initialized the bytes
     let buf: [u8; 8] = unsafe { core::mem::transmute(buf) };
     Ok(u64::from_ne_bytes(buf))
-}
-
-// Custom backend function - to be overridden by user implementations
-#[no_mangle]
-pub unsafe extern "Rust" fn __getrandom_v03_custom(
-    dest: *mut u8,
-    len: usize,
-) -> Result<(), Error> {
-    // Should be overridden by the correct sp1 implementation. Previous version was:
-    // unsafe { sp1_zkvm::syscalls::sys_rand(s.as_mut_ptr(), s.len()) };
-
-    for i in 0..len {
-        *dest.add(i) = (i as u8).wrapping_mul(17).wrapping_add(42);
-    }
-    Ok(())
 }


### PR DESCRIPTION
This isn't really a PR, because I pushed directly to the new v0.3.3-zkvm branch. But it's good for reviewing what I did. Comments still welcome.

getrandom v0.3.3 (which is used by Agave 3.0) changed their backend interface, so this is an updated version of the code needed to use this within an SP1 proof. 

For the moment, this is just a trivial implementation of the function. Succinct should move this to their own fork and hook up the latest version of their randomization internals, which wasn't necessary for me to get this working.